### PR TITLE
Add scraper doctypes

### DIFF
--- a/scraper/scraper/doctype/analysis/analysis.json
+++ b/scraper/scraper/doctype/analysis/analysis.json
@@ -1,0 +1,57 @@
+{
+ "doctype": "DocType",
+ "name": "Analysis",
+ "module": "scraper",
+ "custom": 0,
+ "fields": [
+  {
+   "fieldname": "scrape_job",
+   "fieldtype": "Link",
+   "label": "Scrape Job",
+   "options": "Scrape Job",
+   "reqd": 1
+  },
+  {
+   "fieldname": "kv_metrics",
+   "fieldtype": "Code",
+   "label": "Metrics (JSON)",
+   "options": "JSON"
+  },
+  {
+   "fieldname": "sentiment_score",
+   "fieldtype": "Float",
+   "label": "Sentiment Score"
+  },
+  {
+   "fieldname": "topics",
+   "fieldtype": "Table",
+   "label": "Topics",
+   "options": "Topic"
+  },
+  {
+   "fieldname": "graph_url",
+   "fieldtype": "Data",
+   "label": "Graph URL"
+  }
+ ],
+ "autoname": "field:name",
+ "permissions": [
+  {
+   "role": "Scraping Admin",
+   "read": 1,
+   "write": 1,
+   "create": 1,
+   "delete": 1
+  },
+  {
+   "role": "Data Analyst",
+   "read": 1,
+   "write": 1,
+   "create": 1
+  },
+  {
+   "role": "Viewer",
+   "read": 1
+  }
+ ]
+}

--- a/scraper/scraper/doctype/analysis/analysis.py
+++ b/scraper/scraper/doctype/analysis/analysis.py
@@ -1,0 +1,27 @@
+"""DocType server script for Analysis."""
+from __future__ import annotations
+
+from typing import Optional
+
+import frappe
+from frappe.model.document import Document
+
+
+class Analysis(Document):
+    """Holds processed metrics for a Scrape Job."""
+
+    @frappe.whitelist()
+    def get_latest(self) -> Optional[str]:
+        """Return the most recent Plotly graph URL for this job."""
+        latest = (
+            frappe.get_all(
+                "Analysis",
+                filters={"scrape_job": self.scrape_job},
+                fields=["graph_url"],
+                order_by="creation desc",
+                limit_page_length=1,
+            )
+        )
+        return latest[0].graph_url if latest else None
+
+# EOF

--- a/scraper/scraper/doctype/scrape_job/scrape_job.json
+++ b/scraper/scraper/doctype/scrape_job/scrape_job.json
@@ -1,0 +1,57 @@
+{
+ "doctype": "DocType",
+ "name": "Scrape Job",
+ "module": "scraper",
+ "custom": 0,
+ "fields": [
+  {
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "label": "Status",
+   "options": "Draft\nQueued\nSuccess\nError",
+   "reqd": 1
+  },
+  {
+   "fieldname": "target_type",
+   "fieldtype": "Select",
+   "label": "Target Type",
+   "options": "web\ntwitter",
+   "reqd": 1
+  },
+  {
+   "fieldname": "query",
+   "fieldtype": "Data",
+   "label": "Query/Keyword"
+  },
+  {
+   "fieldname": "url",
+   "fieldtype": "Data",
+   "label": "URL"
+  },
+  {
+   "fieldname": "frequency_cron",
+   "fieldtype": "Data",
+   "label": "Frequency (Cron)"
+  }
+ ],
+ "autoname": "field:name",
+ "permissions": [
+  {
+   "role": "Scraping Admin",
+   "read": 1,
+   "write": 1,
+   "create": 1,
+   "delete": 1
+  },
+  {
+   "role": "Data Analyst",
+   "read": 1,
+   "write": 1,
+   "create": 1
+  },
+  {
+   "role": "Viewer",
+   "read": 1
+  }
+ ]
+}

--- a/scraper/scraper/doctype/scrape_job/scrape_job.py
+++ b/scraper/scraper/doctype/scrape_job/scrape_job.py
@@ -1,0 +1,13 @@
+"""DocType server script for Scrape Job."""
+from __future__ import annotations
+
+import frappe
+from frappe.model.document import Document
+
+
+class ScrapeJob(Document):
+    """Represents a scraping task."""
+
+    pass
+
+# EOF

--- a/scraper/scraper/doctype/scrape_result/scrape_result.json
+++ b/scraper/scraper/doctype/scrape_result/scrape_result.json
@@ -1,0 +1,55 @@
+{
+ "doctype": "DocType",
+ "name": "Scrape Result",
+ "module": "scraper",
+ "custom": 0,
+ "fields": [
+  {
+   "fieldname": "scrape_job",
+   "fieldtype": "Link",
+   "label": "Scrape Job",
+   "options": "Scrape Job",
+   "reqd": 1
+  },
+  {
+   "fieldname": "raw_json",
+   "fieldtype": "Long Text",
+   "label": "Raw JSON"
+  },
+  {
+   "fieldname": "text_clean",
+   "fieldtype": "Text",
+   "label": "Cleaned Text"
+  },
+  {
+   "fieldname": "language",
+   "fieldtype": "Data",
+   "label": "Language"
+  },
+  {
+   "fieldname": "datetime_scraped",
+   "fieldtype": "Datetime",
+   "label": "Datetime Scraped"
+  }
+ ],
+ "autoname": "field:name",
+ "permissions": [
+  {
+   "role": "Scraping Admin",
+   "read": 1,
+   "write": 1,
+   "create": 1,
+   "delete": 1
+  },
+  {
+   "role": "Data Analyst",
+   "read": 1,
+   "write": 1,
+   "create": 1
+  },
+  {
+   "role": "Viewer",
+   "read": 1
+  }
+ ]
+}

--- a/scraper/scraper/doctype/scrape_result/scrape_result.py
+++ b/scraper/scraper/doctype/scrape_result/scrape_result.py
@@ -1,0 +1,13 @@
+"""DocType server script for Scrape Result."""
+from __future__ import annotations
+
+import frappe
+from frappe.model.document import Document
+
+
+class ScrapeResult(Document):
+    """Stores raw scraped data."""
+
+    pass
+
+# EOF

--- a/scraper/scraper/doctype/topic/topic.json
+++ b/scraper/scraper/doctype/topic/topic.json
@@ -1,0 +1,39 @@
+{
+ "doctype": "DocType",
+ "name": "Topic",
+ "module": "scraper",
+ "istable": 1,
+ "custom": 0,
+ "fields": [
+  {
+   "fieldname": "topic",
+   "fieldtype": "Data",
+   "label": "Topic"
+  },
+  {
+   "fieldname": "score",
+   "fieldtype": "Float",
+   "label": "Score"
+  }
+ ],
+ "autoname": "field:name",
+ "permissions": [
+  {
+   "role": "Scraping Admin",
+   "read": 1,
+   "write": 1,
+   "create": 1,
+   "delete": 1
+  },
+  {
+   "role": "Data Analyst",
+   "read": 1,
+   "write": 1,
+   "create": 1
+  },
+  {
+   "role": "Viewer",
+   "read": 1
+  }
+ ]
+}

--- a/scraper/scraper/doctype/topic/topic.py
+++ b/scraper/scraper/doctype/topic/topic.py
@@ -1,0 +1,13 @@
+"""Child table DocType for topics."""
+from __future__ import annotations
+
+import frappe
+from frappe.model.document import Document
+
+
+class Topic(Document):
+    """Represents a single topic entry."""
+
+    pass
+
+# EOF


### PR DESCRIPTION
## Summary
- define Scrape Job, Scrape Result, Analysis and Topic doctypes
- add basic python classes with whitelisted method `get_latest`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685347a8817483259ffd3022e51edb33